### PR TITLE
Correct error message

### DIFF
--- a/vies/fields.py
+++ b/vies/fields.py
@@ -40,7 +40,7 @@ class VATINField(forms.MultiValueField):
                     self._vies_result = vatin.result
                     return super(VATINField, self).clean(value)
             except ValueError as ve:
-                raise ValidationError(ve.message, code='error', params={'value': self.compress(value)})
+                raise ValidationError(str(ve), code='error', params={'value': self.compress(value)})
 
             raise ValidationError(_('%(value)s is not a valid European VAT.'), code='invalid',
                                   params={'value': self.compress(value)})


### PR DESCRIPTION
The ValueError messages from _validate and _verify was not used.
While it's correct that AA12345678 is not a valid VAT the error message should be "AA is not a VIES member country."

The same happens if VIES is unavailable. The previous result from that was "XXXXXX is not a valid European VAT.". With this change the error is the more correct "VIES checkVat service unavailable.".
