### PR TITLE
Add custom validation message for VATINField with the invalid_vat code.

### DIFF
--- a/vies/fields.py
+++ b/vies/fields.py
@@ -12,6 +12,10 @@ class VATINField(forms.MultiValueField):
     """VIES VAT field. That verifies on the fly."""
     hidden_widget = VATINHiddenWidget
 
+    default_error_messages = {
+        'invalid_vat': _('This is not a valid European VAT number.')
+    }
+
     def __init__(self, choices=VIES_COUNTRY_CHOICES, *args, **kwargs):
         max_length = kwargs.pop('max_length', 14)
         fields = (
@@ -19,6 +23,7 @@ class VATINField(forms.MultiValueField):
             forms.CharField(required=False, max_length=max_length)
         )
         kwargs['widget'] = VATINWidget(choices=choices)
+
         super(VATINField, self).__init__(fields=fields, *args, **kwargs)
 
     def compress(self, data_list):
@@ -42,16 +47,8 @@ class VATINField(forms.MultiValueField):
             except ValueError as e:
                 raise ValidationError(str(e), code='error', params={'value': self.compress(value)})
 
-            raise ValidationError(self.error_messages.get('invalid_vat', self._get_invalid_error_message()),
-                                  code='invalid_vat', params={'value': self.compress(value)})
-
-    def _get_invalid_error_message(self):
-        if get_version() >= '1.6':
-            message = _('%(value)s is not a valid European VAT.')
-        else:
-            message = _('The provided VAT number is not valid.')
-
-        return message
+            raise ValidationError(self.error_messages['invalid_vat'], code='invalid_vat',
+                                  params={'value': self.compress(value)})
 
     def vatinData(self):
         return self._vies_result if hasattr(self, '_vies_result') else None

--- a/vies/fields.py
+++ b/vies/fields.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import (unicode_literals, absolute_import)
 
-from django import forms
+from django import forms, get_version
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from . import VATIN, VIES_COUNTRY_CHOICES
@@ -42,8 +42,16 @@ class VATINField(forms.MultiValueField):
             except ValueError as e:
                 raise ValidationError(str(e), code='error', params={'value': self.compress(value)})
 
-            raise ValidationError(self.error_messages.get('invalid_vat', _('%(value)s is not a valid European VAT.')),
+            raise ValidationError(self.error_messages.get('invalid_vat', self._get_invalid_error_message()),
                                   code='invalid_vat', params={'value': self.compress(value)})
+
+    def _get_invalid_error_message(self):
+        if get_version() >= '1.6':
+            message = _('%(value)s is not a valid European VAT.')
+        else:
+            message = _('The provided VAT number is not valid.')
+
+        return message
 
     def vatinData(self):
         return self._vies_result if hasattr(self, '_vies_result') else None

--- a/vies/fields.py
+++ b/vies/fields.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import (unicode_literals, absolute_import)
 
-from django import forms, get_version
+from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from . import VATIN, VIES_COUNTRY_CHOICES

--- a/vies/fields.py
+++ b/vies/fields.py
@@ -42,8 +42,8 @@ class VATINField(forms.MultiValueField):
             except ValueError as e:
                 raise ValidationError(str(e), code='error', params={'value': self.compress(value)})
 
-            raise ValidationError(_('%(value)s is not a valid European VAT.'), code='invalid',
-                                  params={'value': self.compress(value)})
+            raise ValidationError(self.error_messages.get('invalid_vat', _('%(value)s is not a valid European VAT.')),
+                                  code='invalid_vat', params={'value': self.compress(value)})
 
     def vatinData(self):
         return self._vies_result if hasattr(self, '_vies_result') else None

--- a/vies/tests.py
+++ b/vies/tests.py
@@ -199,7 +199,7 @@ class ModelFormTestCase(unittest.TestCase):
         form = VIESFormCustomError16({'vat_0': 'NL', 'vat_1': '0000000000'})
         self.assertFalse(form.is_valid())
         if get_version() > '1.6':
-            self.assertEqual(form.errors['vat'][0], 'NL000000000 is not a valid European VAT')
+            self.assertEqual(form.errors['vat'][0], 'NL0000000000 is not a valid European VAT.')
 
 
 class MockRequest(object):

--- a/vies/tests.py
+++ b/vies/tests.py
@@ -180,18 +180,18 @@ class ModelFormTestCase(unittest.TestCase):
         form = VIESForm({'vat_0': 'NL', 'vat_1': '0000000000'})
         self.assertFalse(form.is_valid())
         if get_version() >= '1.6':
-            self.assertEqual(form.errors['vat'][0], u'NL0000000000 is not a valid European VAT.')
+            self.assertEqual(form.errors['vat'][0], 'NL0000000000 is not a valid European VAT.')
 
     def test_invalid_error_message_1_5(self):
         form = VIESForm({'vat_0': 'NL', 'vat_1': '0000000000'})
         self.assertFalse(form.is_valid())
         if not get_version() >= '1.6':
-            self.assertEqual(form.errors['vat'][0], u'The provided VAT number is not valid.')
+            self.assertEqual(form.errors['vat'][0], 'The provided VAT number is not valid.')
 
     def test_custom_invalid_error_message(self):
         form = VIESFormCustomError({'vat_0': 'NL', 'vat_1': '0000000000'})
         self.assertFalse(form.is_valid())
-        self.assertEqual(form.errors['vat'][0], u'This VAT number is not valid')
+        self.assertEqual(form.errors['vat'][0], 'This VAT number is not valid')
 
 
 class MockRequest(object):

--- a/vies/tests.py
+++ b/vies/tests.py
@@ -45,6 +45,15 @@ class EmptyVIESForm(Form):
     vat = fields.VATINField(required=False)
 
 
+custom_error = {
+    'invalid_vat': 'This VAT number is not valid'
+}
+
+
+class VIESFormCustomError(Form):
+    vat = fields.VATINField(error_messages=custom_error)
+
+
 class VIESTestCase(unittest.TestCase):
     def setUp(self):
         pass
@@ -165,6 +174,16 @@ class ModelFormTestCase(unittest.TestCase):
         data = form.fields['vat'].vatinData()
 
         self.assertEqual(data['name'], 'JIETER')
+
+    def test_invalid_error_message(self):
+        form = VIESForm({'vat_0': 'NL', 'vat_1': '0000000000'})
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['vat'][0], u'NL0000000000 is not a valid European VAT.')
+
+    def test_custom_invalid_error_message(self):
+        form = VIESFormCustomError({'vat_0': 'NL', 'vat_1': '0000000000'})
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['vat'][0], u'This VAT number is not valid')
 
 
 class MockRequest(object):

--- a/vies/tests.py
+++ b/vies/tests.py
@@ -55,6 +55,15 @@ class VIESFormCustomError(Form):
     vat = fields.VATINField(error_messages=custom_error)
 
 
+custom_error_16 = {
+    'invalid_vat': '%(value)s is not a valid European VAT.'
+}
+
+
+class VIESFormCustomError16(Form):
+    vat = fields.VATINField(error_messages=custom_error_16)
+
+
 class VIESTestCase(unittest.TestCase):
     def setUp(self):
         pass
@@ -176,22 +185,21 @@ class ModelFormTestCase(unittest.TestCase):
 
         self.assertEqual(data['name'], 'JIETER')
 
-    def test_invalid_error_message_1_6(self):
+    def test_invalid_error_message(self):
         form = VIESForm({'vat_0': 'NL', 'vat_1': '0000000000'})
         self.assertFalse(form.is_valid())
-        if get_version() >= '1.6':
-            self.assertEqual(form.errors['vat'][0], 'NL0000000000 is not a valid European VAT.')
-
-    def test_invalid_error_message_1_5(self):
-        form = VIESForm({'vat_0': 'NL', 'vat_1': '0000000000'})
-        self.assertFalse(form.is_valid())
-        if not get_version() >= '1.6':
-            self.assertEqual(form.errors['vat'][0], 'The provided VAT number is not valid.')
+        self.assertEqual(form.errors['vat'][0], 'This is not a valid European VAT number.')
 
     def test_custom_invalid_error_message(self):
         form = VIESFormCustomError({'vat_0': 'NL', 'vat_1': '0000000000'})
         self.assertFalse(form.is_valid())
         self.assertEqual(form.errors['vat'][0], 'This VAT number is not valid')
+
+    def test_custom_invalid_error_message_with_value(self):
+        form = VIESFormCustomError16({'vat_0': 'NL', 'vat_1': '0000000000'})
+        self.assertFalse(form.is_valid())
+        if get_version() > '1.6':
+            self.assertEqual(form.errors['vat'][0], 'NL000000000 is not a valid European VAT')
 
 
 class MockRequest(object):

--- a/vies/tests.py
+++ b/vies/tests.py
@@ -4,6 +4,7 @@ from __future__ import (unicode_literals, absolute_import)
 from mock import patch
 from suds import WebFault
 
+from django import get_version
 from django.contrib.admin.options import ModelAdmin
 from django.contrib.admin.sites import AdminSite
 from django.db.models import Model, CharField
@@ -175,10 +176,17 @@ class ModelFormTestCase(unittest.TestCase):
 
         self.assertEqual(data['name'], 'JIETER')
 
-    def test_invalid_error_message(self):
+    def test_invalid_error_message_1_6(self):
         form = VIESForm({'vat_0': 'NL', 'vat_1': '0000000000'})
         self.assertFalse(form.is_valid())
-        self.assertEqual(form.errors['vat'][0], u'NL0000000000 is not a valid European VAT.')
+        if get_version() >= '1.6':
+            self.assertEqual(form.errors['vat'][0], u'NL0000000000 is not a valid European VAT.')
+
+    def test_invalid_error_message_1_5(self):
+        form = VIESForm({'vat_0': 'NL', 'vat_1': '0000000000'})
+        self.assertFalse(form.is_valid())
+        if not get_version() >= '1.6':
+            self.assertEqual(form.errors['vat'][0], u'The provided VAT number is not valid.')
 
     def test_custom_invalid_error_message(self):
         form = VIESFormCustomError({'vat_0': 'NL', 'vat_1': '0000000000'})


### PR DESCRIPTION
I would like to override the default validation message for the VATINField. You can pass an error_messages dictionary for the field based on the django documentation, the validation error ignored this error dict.

https://docs.djangoproject.com/en/1.7/ref/forms/fields/#error-messages

I've changed the code to ```invalid_vat``` from ```invalid``` because MultiValueField already has a default value.