### PR TITLE
Blank VATINField did not work in Django admin

### DIFF
--- a/vies/fields.py
+++ b/vies/fields.py
@@ -28,27 +28,21 @@ class VATINField(forms.MultiValueField):
 
     def compress(self, data_list):
         if data_list:
-            return "".join(data_list)
-        return ''
-
-    def clean(self, value):
-        if not value or not isinstance(value, (list, tuple)):
-            if not value or not [v for v in value if v not in self.empty_values]:
-                if self.required:
-                    raise ValidationError(self.error_messages['required'], code='required')
-                else:
-                    return self.compress([])
-        else:
+            value = ''.join(data_list)
             try:
-                vatin = VATIN(*value)
-                if vatin.is_valid():
-                    self._vies_result = vatin.result
-                    return super(VATINField, self).clean(value)
+                vatin = VATIN(*data_list)
             except ValueError as e:
-                raise ValidationError(str(e), code='error', params={'value': self.compress(value)})
-
-            raise ValidationError(self.error_messages['invalid_vat'], code='invalid_vat',
-                                  params={'value': self.compress(value)})
+                raise ValidationError(str(e), code='error', params={'value': value})
+            if vatin.is_valid():
+                self._vies_result = vatin.result
+            else:
+                raise ValidationError(
+                    self.error_messages['invalid_vat'], 
+                    code='invalid_vat',
+                    params={'value': value})
+        else:
+            value = ''
+        return value
 
     def vatinData(self):
         return self._vies_result if hasattr(self, '_vies_result') else None

--- a/vies/models.py
+++ b/vies/models.py
@@ -15,7 +15,10 @@ class VATINField(CharField):
         super(VATINField, self).__init__(*args, **kwargs)
 
     def formfield(self, **kwargs):
-        defaults = {'form_class': fields.VATINField}
+        defaults = {
+            'form_class': fields.VATINField,
+            'required': not (self.blank or self.null)
+        }
         defaults.update(kwargs)
         return super(VATINField, self).formfield(**defaults)
 

--- a/vies/widgets.py
+++ b/vies/widgets.py
@@ -46,6 +46,8 @@ class VATINWidget(forms.MultiWidget):
             except:
                 pass
             return [country, code]
+        else:
+            return [None, None]
 
     def format_output(self, rendered_widgets):
         return "%s&nbsp;%s" % (rendered_widgets[0], rendered_widgets[1])


### PR DESCRIPTION
When using a `VATINField(blank=True)` on a model, and attempting to save it (while leaving it empty) in the Django admin we run into an exception:

```
Request Method: POST

Django Version: 1.6.5
Python Version: 2.7.6

Traceback:
File "/somewhere/virtualenv/2.7/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  112.                     response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/somewhere/virtualenv/2.7/lib/python2.7/site-packages/django/contrib/admin/options.py" in wrapper
  432.                 return self.admin_site.admin_view(view)(*args, **kwargs)
File "/somewhere/virtualenv/2.7/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapped_view
  99.                     response = view_func(request, *args, **kwargs)
File "/somewhere/virtualenv/2.7/lib/python2.7/site-packages/django/views/decorators/cache.py" in _wrapped_view_func
  52.         response = view_func(request, *args, **kwargs)
File "/somewhere/virtualenv/2.7/lib/python2.7/site-packages/django/contrib/admin/sites.py" in inner
  198.             return view(request, *args, **kwargs)
File "/somewhere/virtualenv/2.7/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapper
  29.             return bound_func(*args, **kwargs)
File "/somewhere/virtualenv/2.7/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapped_view
  99.                     response = view_func(request, *args, **kwargs)
File "/somewhere/virtualenv/2.7/lib/python2.7/site-packages/django/utils/decorators.py" in bound_func
  25.                 return func(self, *args2, **kwargs2)
File "/somewhere/virtualenv/2.7/lib/python2.7/site-packages/django/db/transaction.py" in inner
  371.                 return func(*args, **kwargs)
File "/somewhere/virtualenv/2.7/lib/python2.7/site-packages/django/contrib/admin/options.py" in change_view
  1232.                 change_message = self.construct_change_message(request, form, formsets)
File "/somewhere/virtualenv/2.7/lib/python2.7/site-packages/django/contrib/admin/options.py" in construct_change_message
  803.         if form.changed_data:
File "/somewhere/virtualenv/2.7/lib/python2.7/site-packages/django/forms/forms.py" in changed_data
  359.                 elif field._has_changed(initial_value, data_value):
File "/somewhere/virtualenv/2.7/lib/python2.7/site-packages/django/forms/fields.py" in _has_changed
  1030.         for field, initial, data in zip(self.fields, initial, data):

Exception Type: TypeError at /admin/somewhere/
Exception Value: zip argument #3 must support iteration
```
While debugging what was going on I also noticed there was a `def clean` on the `MultiValueField`, which is not supposed to be according to the Django docs:

https://docs.djangoproject.com/en/1.7/ref/forms/fields/#django.forms.MultiValueField -- This field is abstract and must be subclassed. In contrast with the single-value fields, subclasses of MultiValueField *must not implement clean()* ...

So I fixed that as well.


