### PR TITLE
[1/2] Fix server errors when the VIES service is unavailable.

### DIFF
--- a/vies/__init__.py
+++ b/vies/__init__.py
@@ -9,6 +9,7 @@ from retrying import retry
 from suds import WebFault
 from suds.client import Client
 
+logger = logging.getLogger(__name__)
 
 logging.basicConfig(level=logging.ERROR)
 logging.getLogger('suds.client').setLevel(logging.INFO)
@@ -117,4 +118,5 @@ class VATIN(object):
             self.result = self.client.service.checkVat(self.country_code, self.number)
             return self.result.valid
         except WebFault:
+            logger.exception('VIES checkVat service unavailable.')
             raise ValueError('VIES checkVat service unavailable.')

--- a/vies/__init__.py
+++ b/vies/__init__.py
@@ -9,7 +9,7 @@ from retrying import retry
 from suds import WebFault
 from suds.client import Client
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('vies')
 
 logging.basicConfig(level=logging.ERROR)
 logging.getLogger('suds.client').setLevel(logging.INFO)

--- a/vies/fields.py
+++ b/vies/fields.py
@@ -31,9 +31,10 @@ class VATINField(forms.MultiValueField):
             value = ''.join(data_list)
             try:
                 vatin = VATIN(*data_list)
+                is_valid = vatin.is_valid()
             except ValueError as e:
                 raise ValidationError(str(e), code='error', params={'value': value})
-            if vatin.is_valid():
+            if is_valid:
                 self._vies_result = vatin.result
             else:
                 raise ValidationError(

--- a/vies/tests.py
+++ b/vies/tests.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import (unicode_literals, absolute_import)
 
+import logging
+
 from mock import patch
 from suds import WebFault
 
@@ -110,8 +112,12 @@ class VIESTestCase(unittest.TestCase):
 
         v = VATIN(VALID_VIES_COUNTRY_CODE, VALID_VIES_NUMBER)
 
+        logging.getLogger('vies').setLevel(logging.CRITICAL)
+
         with self.assertRaises(ValueError):
             v.is_valid()
+
+        logging.getLogger('vies').setLevel(logging.NOTSET)
 
         mock_checkVat.assert_called_with(VALID_VIES_COUNTRY_CODE, VALID_VIES_NUMBER)
 


### PR DESCRIPTION
Hi!

I'm using your package in a webshop checkout flow. The VIES service has gone offline so many times during the last few days. Because the `is_valid()` check is placed outside the except cause in `compress()`, the form validation will raise a `ValueError` right now. Hence, customers are faced with a 500 page instead of an error message. This patch fixes that.

The error is also logged, so admins can still be notified (e.g. via sentry)