### PR TITLE
Introduction of AppConfig and new setting allow_server_error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,6 @@
    :alt: Join the chat at https://gitter.im/codingjoe/django-vies
    :target: https://gitter.im/codingjoe/django-vies?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
-
 ===========
 Django-VIES
 ===========
@@ -41,6 +40,12 @@ Latest Development
 ::
 
     pip install -e git://github.com/codingjoe/django-vies.git#egg=django-vies
+
+``INSTALLED_APPS``
+++++++++++++++++++
+
+Add ``'vies.apps.ViesConfig'`` to your ``INSTALLED_APPS``.
+
 
 Usage
 -----
@@ -71,6 +76,21 @@ Usage
        name = "JIETER"
        address = "(...)"
      }
+
+
+Settings
+--------
+
+``allow_server_error``
+++++++++++++++++++++++
+
+Throws a ``ValidationError`` if the VIES check VAT service is currently
+unavailable. Replace ``'vies.apps.ViesConfig'`` with
+``'vies.apps.ViesDisallowServerErrorConfig'`` in
+``settings.INSTALLED_APPS`` to disable this behavior. This change will
+insert a empty string for the ``VATINField`` in ``cleaned_data``, so the
+VATIN will not be saved. You have to inform the user about this by using
+your own implementation.
 
 
 Translations

--- a/vies/__init__.py
+++ b/vies/__init__.py
@@ -10,6 +10,8 @@ from retrying import retry
 from suds import WebFault
 from suds.client import Client
 
+default_app_config = 'vies.apps.ViesConfig'
+
 logger = logging.getLogger('vies')
 
 logging.basicConfig(level=logging.ERROR)

--- a/vies/apps.py
+++ b/vies/apps.py
@@ -1,0 +1,12 @@
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class ViesConfig(AppConfig):
+    name = 'vies'
+    verbose_name = _("Vies")
+    allow_server_error = True
+
+
+class ViesDisallowServerErrorConfig(ViesConfig):
+    allow_server_error = False

--- a/vies/tests.py
+++ b/vies/tests.py
@@ -157,17 +157,17 @@ class ModelTestCase(unittest.TestCase):
 class FieldTestCase(unittest.TestCase):
 
     @patch('vies.Client')
-    @override_settings(INSTALLED_APPS=['vies.apps.ViesDisallowServerErrorConfig'])
-    def test_disable_validation_when_suds_web_fault_exception(self, mock_client):
-        """Disable Validation if WebFault exception and AppConfig.allow_server_error=False."""
+    @override_settings(INSTALLED_APPS=['vies.apps.ViesDisallowServerErrorConfig'])  # noqa
+    def test_not_raises_when_suds_web_fault_exception(self, mock_client):
+        """Do not raise if WebFault exception and allow_server_error=False."""
         mock_check_vat = mock_client.return_value.service.checkVat
         mock_check_vat.side_effect = WebFault(500, 'error')
 
         logging.getLogger('vies').setLevel(logging.CRITICAL)
 
         v = fields.VATINField(VIES_COUNTRY_CHOICES)
-
-        self.assertEqual(v.clean([VALID_VIES_COUNTRY_CODE, VALID_VIES_NUMBER]), '')
+        out = v.clean([VALID_VIES_COUNTRY_CODE, VALID_VIES_NUMBER])
+        self.assertEqual(out, '')
 
         logging.getLogger('vies').setLevel(logging.NOTSET)
 

--- a/vies/tests.py
+++ b/vies/tests.py
@@ -8,11 +8,12 @@ from django.contrib.admin.options import ModelAdmin
 from django.contrib.admin.sites import AdminSite
 from django.db.models import CharField, Model
 from django.forms import Form, ModelForm
+from django.test import override_settings
 from django.utils import unittest
 from mock import patch
 from suds import WebFault
 
-from . import VATIN, fields, models
+from . import VATIN, VIES_COUNTRY_CHOICES, fields, models
 
 VALID_VIES = 'DE284754038'
 VALID_VIES_COUNTRY_CODE = 'DE'
@@ -151,6 +152,24 @@ class ModelTestCase(unittest.TestCase):
         vies_received = VIESModel.objects.get(pk=vies_saved.pk)
         self.assertNotEqual(VIESModel.objects.count(), 0)
         self.assertEqual(vies_received.vat, VALID_VIES)
+
+
+class FieldTestCase(unittest.TestCase):
+
+    @patch('vies.Client')
+    @override_settings(INSTALLED_APPS=['vies.apps.ViesDisallowServerErrorConfig'])
+    def test_disable_validation_when_suds_web_fault_exception(self, mock_client):
+        """Disable Validation if WebFault exception and AppConfig.allow_server_error=False."""
+        mock_check_vat = mock_client.return_value.service.checkVat
+        mock_check_vat.side_effect = WebFault(500, 'error')
+
+        logging.getLogger('vies').setLevel(logging.CRITICAL)
+
+        v = fields.VATINField(VIES_COUNTRY_CHOICES)
+
+        self.assertEqual(v.clean([VALID_VIES_COUNTRY_CODE, VALID_VIES_NUMBER]), '')
+
+        logging.getLogger('vies').setLevel(logging.NOTSET)
 
 
 class ModelFormTestCase(unittest.TestCase):


### PR DESCRIPTION
We would like to handle the [ValidationError](https://github.com/codingjoe/django-vies/blob/master/vies/fields.py#L40) if the VIES check VAT service is currently unavailable.
To handle the ``ValidationError`` for example in a ``form``and the ``admin`` we think it is a better solution to introduce a ``setting`` to disable the ``ValidationError`` .

We also think that we can use the [AppConfig feature of Django](https://docs.djangoproject.com/en/1.8/ref/applications/#django.apps.AppConfig) to set ``allow_server_error`` instead in the ``settings.py`` with a prefix.

The ``setting`` with the name ``allow_server_error`` is by default ``True`` and is set by [ViesConfig](https://github.com/transcode-de/django-vies/blob/introduce-appconfig-and-allow-server-error-setting/vies/apps.py#L8).
If you want to set `allow_server_error`` to ``False` you should follow the section in the [README](https://github.com/transcode-de/django-vies/tree/introduce-appconfig-and-allow-server-error-setting#allow_server_error).