### PR TITLE
Use six to make instance check of str py2 compatiple

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import pytest
 from django.core.exceptions import ValidationError
 

--- a/vies/validators.py
+++ b/vies/validators.py
@@ -1,3 +1,4 @@
+import six
 from django.utils.deconstruct import deconstructible
 from django.utils.translation import ugettext_lazy as _
 
@@ -18,7 +19,7 @@ class VATINValidator(object):
         self.validate = validate
 
     def __call__(self, value):
-        if isinstance(value, str):
+        if isinstance(value, six.text_type):
             value = VATIN.from_str(value)
         if self.verify:
             value.verify()

--- a/vies/validators.py
+++ b/vies/validators.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import six
 from django.utils.deconstruct import deconstructible
 from django.utils.translation import ugettext_lazy as _


### PR DESCRIPTION
Sorry,

I introduced with the last [PR](https://github.com/codingjoe/django-vies/pull/33) a `instance check of str` without handling Python 2 compatibility.
The check happens in the [Validator](https://github.com/codingjoe/django-vies/blob/master/vies/validators.py#L21) with the code `if isinstance(value, str):`

With this PR instance check of `six.text_type` fixes the behavior in Python2 and works also in Python3.