### PR TITLE
Disable logging #45

### DIFF
--- a/vies/__init__.py
+++ b/vies/__init__.py
@@ -7,8 +7,5 @@ __version__ = "3.1.1"
 
 logger = logging.getLogger('vies')
 
-logging.basicConfig(level=logging.ERROR)
-logging.getLogger('suds.client').setLevel(logging.INFO)
-
 VIES_WSDL_URL = str('http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl')  # NoQA
 VATIN_MAX_LENGTH = 14


### PR DESCRIPTION
It was required by our project to drop these lines. It's better when enabling logging is done by the project itself, not the external library.

https://github.com/codingjoe/django-vies/issues/45