### PR TITLE
Django 1.11 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
   matrix:
     - DJANGO="Django<1.9,>=1.8"
     - DJANGO="Django<1.10,>=1.9"
+    - DJANGO="Django<1.11,>=1.10"
+    - DJANGO="Django<1.12,>=1.11"
     - DJANGO="-e git+https://github.com/django/django.git@master#egg=Django"
 matrix:
   fast_finish: true

--- a/vies/forms/fields.py
+++ b/vies/forms/fields.py
@@ -26,6 +26,10 @@ class VATINField(forms.MultiValueField):
             forms.CharField(required=False, max_length=max_length)
         )
 
+        # In Django 1.11+, ignore the `empty_value` parameter added by the
+        # `CharField` superclass at the end of `VATINField.formfield`.
+        kwargs.pop('empty_value', None)
+
         super(VATINField, self).__init__(fields=fields, *args, **kwargs)
 
     def compress(self, data_list):


### PR DESCRIPTION
This commit adds a workaround to ignore the `django.db.models.CharField.empty_value` parameter that was added in Django 1.11. This parameter is passed to the `django.forms.MultiValueField`, which does not support it.