### PR TITLE
Fix spelling of "countries" where appropriate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ e.g.
         vat = VATINField(validators=[VATINValidator(verify=True, validate=True)])
 
 ``validate=True`` will tell the validator to validate against the VIES API.
-``verify`` is enabled on by default and will only verify that the VATIN matches the countries specifications.
+``verify`` is enabled on by default and will only verify that the VATIN matches the country's specifications.
 
 It is recommended to perform VIES API validation inside an asynchronous task.
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -53,7 +53,7 @@ class TestVATIN(object):
         v = VATIN('IE', '1234567890')
         with pytest.raises(ValidationError) as e:
             v.verify()
-        assert 'IE1234567890 does not match the countries VAT ID specifications.' in e.value
+        assert "IE1234567890 does not match the country's VAT ID specifications." in e.value
 
     def test_is_not_valid(self):
         """Invalid number."""

--- a/vies/locale/fr/LC_MESSAGES/django.po
+++ b/vies/locale/fr/LC_MESSAGES/django.po
@@ -28,7 +28,7 @@ msgstr "%s n'est pas un état membre de l'Union Européenne."
 
 #: vies/types.py:144
 #, python-format
-msgid "%s does not match the countries VAT ID specifications."
+msgid "%s does not match the country's VAT ID specifications."
 msgstr "%s n'est pas un numéro de TVA intracommunautaire valide pour ce pays."
 
 #: vies/types.py:153

--- a/vies/locale/it/LC_MESSAGES/django.po
+++ b/vies/locale/it/LC_MESSAGES/django.po
@@ -34,7 +34,7 @@ msgstr "%s non e' un paese membro della Comunità Europea"
 
 #: types.py:144
 #, python-format
-msgid "%s does not match the countries VAT ID specifications."
+msgid "%s does not match the country's VAT ID specifications."
 msgstr "%s non corrisponde alla partita IVA del paese specificato"
 
 #: types.py:153

--- a/vies/types.py
+++ b/vies/types.py
@@ -141,7 +141,7 @@ class VATIN(object):
             VIES_OPTIONS[self.country_code]
         ))
         if not country['validator'].match("%s%s" % (self.country_code, self.number)):
-            msg = ugettext("%s does not match the countries VAT ID specifications.")
+            msg = ugettext("%s does not match the country's VAT ID specifications.")
             raise ValidationError(msg % self)
 
     def verify(self):


### PR DESCRIPTION
The possessive form of "country", "country's" should be used instead of the plural form "countries", as in all cases it is referring to the VAT number specification provided by the country in question. This word appears in an error message in the form UI in `vies/types.py`