### PR TITLE
Edited the regex for Belgium

### DIFF
--- a/vies/types.py
+++ b/vies/types.py
@@ -18,7 +18,7 @@ def fr_format(v):
 
 VIES_OPTIONS = {
     "AT": ("Austria", re.compile(r"^ATU\d{8}$")),
-    "BE": ("Belgium", re.compile(r"^BE0?\d{9}$")),
+    "BE": ("Belgium", re.compile(r"^BE(0|1)\d{9}$")),
     "BG": ("Bulgaria", re.compile(r"^BG\d{9,10}$")),
     "HR": ("Croatia", re.compile(r"^HR\d{11}$")),
     "CY": ("Cyprus", re.compile(r"^CY\d{8}[A-Z]$")),


### PR DESCRIPTION
First digit can now be "0" or "1"
Source : https://economie.fgov.be/en/themes/enterprises/crossroads-bank-enterprises/actualities/structure-company-number-first