### PR TITLE
Add XI for Northern Ireland VAT numbers

### DIFF
--- a/vies/types.py
+++ b/vies/types.py
@@ -44,6 +44,7 @@ VIES_OPTIONS = {
     "SE": ("Sweden", re.compile(r"^SE\d{10}01$")),
     "SI": ("Slovenia", re.compile(r"^SI\d{8}$")),
     "SK": ("Slovakia", re.compile(r"^SK\d{10}$")),
+    "XI": ("Northern Ireland", re.compile(r"^XI\d{9}$")),
 }
 
 VIES_COUNTRY_CHOICES = sorted(


### PR DESCRIPTION
Northern Ireland is supported in VIES using `XI` as the country identifier.

This adds support for this.

```
from vies import VIES_WSDL_URL
from zeep import Client

client = Client(VIES_WSDL_URL)
result = client.service.checkVat("XI", "151308443")
print(result)
```