### PR TITLE
Pass attrs from VATINField to VATINWidget and sub-widgets (#159)

### DIFF
--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -10,6 +10,7 @@ from tests import VALID_VIES, VALID_VIES_COUNTRY_CODE, VALID_VIES_NUMBER
 from tests.testapp.forms import EmptyVIESModelForm, VIESModelForm
 from tests.testapp.models import VIESModel
 from vies.forms import VATINWidget
+from vies.forms.fields import VATINField
 
 
 class ModelTestCase(TestCase):
@@ -114,6 +115,38 @@ class TestWidget:
             [VALID_VIES_COUNTRY_CODE, VALID_VIES_NUMBER]
         ) == (VALID_VIES_COUNTRY_CODE, VALID_VIES_NUMBER)
         assert VATINWidget().decompress(None) == (None, None)
+
+    def test_no_attrs(self):
+        widget = VATINWidget()
+        assert "class" not in widget.attrs
+        assert "class" not in widget.widgets[0].attrs
+        assert "class" not in widget.widgets[1].attrs
+
+    def test_attrs(self):
+        widget = VATINWidget(attrs={"class": "someclass"})
+        assert widget.attrs["class"] == "someclass"
+        assert widget.widgets[0].attrs["class"] == "someclass"
+        assert widget.widgets[1].attrs["class"] == "someclass"
+
+
+class TestField:
+    def test_no_attrs(self):
+        field = VATINField()
+        assert "class" not in field.widget.attrs
+        assert "class" not in field.widget.widgets[0].attrs
+        assert "class" not in field.widget.widgets[1].attrs
+
+    def test_attrs(self):
+        field = VATINField(attrs={"class": "someclass"})
+        assert field.widget.attrs["class"] == "someclass"
+        assert field.widget.widgets[0].attrs["class"] == "someclass"
+        assert field.widget.widgets[1].attrs["class"] == "someclass"
+
+    def test_attrs_from_widget(self):
+        field = VATINField(widget=VATINWidget(attrs={"class": "otherclass"}))
+        assert field.widget.attrs["class"] == "otherclass"
+        assert field.widget.widgets[0].attrs["class"] == "otherclass"
+        assert field.widget.widgets[1].attrs["class"] == "otherclass"
 
 
 class MockRequest:

--- a/vies/forms/fields.py
+++ b/vies/forms/fields.py
@@ -9,12 +9,13 @@ from .widgets import VATINHiddenWidget, VATINWidget
 
 class VATINField(forms.MultiValueField):
     hidden_widget = VATINHiddenWidget
-    widget = VATINWidget
 
     def __init__(self, choices=VIES_COUNTRY_CHOICES, *args, **kwargs):
         max_length = kwargs.pop("max_length", VATIN_MAX_LENGTH)
 
-        kwargs["widget"] = self.widget(choices=choices)
+        attrs = kwargs.pop("attrs", None)
+        widget = kwargs.pop("widget", VATINWidget(choices=choices, attrs=attrs))
+        kwargs["widget"] = widget
         kwargs.setdefault("validators", [VATINValidator()])
 
         fields = (

--- a/vies/forms/widgets.py
+++ b/vies/forms/widgets.py
@@ -11,7 +11,10 @@ EMPTY_VALUES = (None, "")
 
 class VATINWidget(forms.MultiWidget):
     def __init__(self, choices=VIES_COUNTRY_CHOICES, attrs=None):
-        widgets = (forms.Select(choices=choices), forms.TextInput())
+        widgets = (
+            forms.Select(choices=choices, attrs=attrs),
+            forms.TextInput(attrs=attrs),
+        )
         super().__init__(widgets, attrs)
 
     def value_from_datadict(self, data, files, name):


### PR DESCRIPTION
This change allows HTML attributes (e.g. {"class": "form-control"})
passed to VATINField to be propagated down to VATINWidget.

Both sub-widgets (the <select> for country code and the <input> for the
VAT number) now receive the attrs, ensuring consistent styling and
behavior.

The related issue (#159) suggested forwarding attrs to the text input.
Here I forwarded attrs to both the select and the input so that styling
(e.g. Bootstrap classes) applies uniformly. If the project prefers
limiting this to just the text input, I'm happy to adjust.

Tests were added for VATINWidget and VATINField to ensure attrs are
propagated correctly.